### PR TITLE
fix: add timeouts and wrap network errors in EasynewsError

### DIFF
--- a/easynews_client.py
+++ b/easynews_client.py
@@ -12,14 +12,22 @@ You'll need a valid Easynews account. Use responsibly and per Easynews TOS.
 from __future__ import annotations
 
 import base64
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import requests
+from requests.exceptions import RequestException
 
 
 EASYNEWS_BASE = "https://members.easynews.com"
+
+_LOGIN_TIMEOUT = 15
+_SEARCH_TIMEOUT = 30
+_DOWNLOAD_TIMEOUT = 60
+
+logger = logging.getLogger(__name__)
 
 
 class EasynewsError(Exception):
@@ -70,11 +78,16 @@ class EasynewsClient:
         Prime session and validate credentials using a quick authenticated call.
         This relies on HTTP Basic Auth configured on the session.
         """
-        self.s.get(f"{EASYNEWS_BASE}/2.0/")
-        check = self.s.get(
-            f"{EASYNEWS_BASE}/2.0/search/solr-search/?fly=2&gps=test&sb=1&pno=1&pby=1&u=1&chxu=1&chxgx=1&st=basic&s1=dtime&s1d=-&sS=3&vv=1&fty%5B%5D=VIDEO",
-            allow_redirects=True,
-        )
+        try:
+            self.s.get(f"{EASYNEWS_BASE}/2.0/", timeout=_LOGIN_TIMEOUT)
+            check = self.s.get(
+                f"{EASYNEWS_BASE}/2.0/search/solr-search/?fly=2&gps=test&sb=1&pno=1&pby=1&u=1&chxu=1&chxgx=1&st=basic&s1=dtime&s1d=-&sS=3&vv=1&fty%5B%5D=VIDEO",
+                allow_redirects=True,
+                timeout=_LOGIN_TIMEOUT,
+            )
+        except RequestException as e:
+            logger.exception("Network error during Easynews login")
+            raise EasynewsError(f"Network error during Easynews login: {e}") from e
         if check.status_code in (401, 403):
             raise EasynewsError("Unauthorized; check username/password")
 
@@ -123,9 +136,13 @@ class EasynewsClient:
         )
         full_url = f"{url}?{query_params}"
 
-        r = self.s.get(full_url)
-        r.raise_for_status()
-        return r.json()
+        try:
+            r = self.s.get(full_url, timeout=_SEARCH_TIMEOUT)
+            r.raise_for_status()
+            return r.json()
+        except RequestException as e:
+            logger.exception("Search request failed for query '%s'", query)
+            raise EasynewsError(f"Search request failed: {e}") from e
 
     @staticmethod
     def _collect_items(json_data: Dict[str, Any]) -> List[SearchItem]:
@@ -196,7 +213,11 @@ class EasynewsClient:
 
     def download_nzb(self, payload: Dict[str, str], out_path: str) -> str:
         url = f"{EASYNEWS_BASE}/2.0/api/dl-nzb"
-        r = self.s.post(url, data=payload, stream=True)
+        try:
+            r = self.s.post(url, data=payload, stream=True, timeout=_DOWNLOAD_TIMEOUT)
+        except RequestException as e:
+            logger.exception("NZB download request failed")
+            raise EasynewsError(f"NZB download request failed: {e}") from e
         if r.status_code != 200:
             raise EasynewsError(f"NZB creation failed: HTTP {r.status_code}")
 

--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional, Set
 from urllib.parse import quote
 
+import requests
 from flask import Flask, Response, request
 import json
 
@@ -973,11 +974,16 @@ def api():
             )
             return resp
         si = to_search_item(d)
-        c = client()
-        payload = c.build_nzb_payload([si], name=d.get("title"))
-        # fetch content
-        url = "https://members.easynews.com/2.0/api/dl-nzb"
-        r = c.s.post(url, data=payload)
+        try:
+            c = client()
+            payload = c.build_nzb_payload([si], name=d.get("title"))
+            # fetch content
+            url = "https://members.easynews.com/2.0/api/dl-nzb"
+            r = c.s.post(url, data=payload, timeout=60)
+        except EasynewsError as e:
+            return Response(f"Upstream error: {e}", status=502)
+        except requests.exceptions.RequestException as e:
+            return Response(f"Upstream network error: {e}", status=502)
         if r.status_code != 200:
             return Response(f"Upstream error {r.status_code}", status=502)
         # Name file as title.nzb


### PR DESCRIPTION
## Summary

Adds request timeouts and proper exception handling around all `requests` calls in `easynews_client.py` and the inline NZB-download path in `server.py`.

## Why

**No timeouts.** Every `requests` call (login probe, search, NZB download) runs without a `timeout=`. If Easynews is slow or hangs, a Gunicorn worker is held indefinitely. With the default `--workers 4`, four hung requests is enough to take the indexer offline.

**Unhandled `RequestException`.** Network-layer errors (DNS, TCP RST, connection reset, read timeout once timeouts are added) propagate out of the search/download routes as bare Flask 500s with no log line. Prowlarr flags the indexer as failing its health check, and the operator has nothing to debug.

## Changes

- `easynews_client.py`
  - Add module-level `logger` and timeout constants (`_LOGIN_TIMEOUT=15`, `_SEARCH_TIMEOUT=30`, `_DOWNLOAD_TIMEOUT=60`)
  - Wrap network calls in `login()`, `search()`, and `download_nzb()` in `try/except RequestException`, log via `logger.exception(...)`, and re-raise as `EasynewsError` so callers can handle uniformly
- `server.py`
  - Apply the same pattern to the inline `c.s.post(...)` in the `t=get`/`t=getnzb` route, returning HTTP 502 with a descriptive message instead of an unhandled 500

No behaviour change on the happy path; the timeouts are conservative and well above any realistic Easynews response time observed in production.

## Test plan

- [x] `docker build` succeeds against the patched tree
- [x] Container boots and `/api?t=caps` returns the expected categories XML
- [x] `/api?t=tvsearch&q=&cat=5000` fallback returns an item with `<category>5000</category>`
- [ ] Force a network failure (e.g. block egress to `members.easynews.com`) and confirm a 502 with a useful log line, not a 500 with a blank traceback